### PR TITLE
Add provider health history tracking for observability & diagnostics

### DIFF
--- a/lib/monitoring/providerHealthHistory.ts
+++ b/lib/monitoring/providerHealthHistory.ts
@@ -1,0 +1,43 @@
+export type ProviderHealthStatus = "healthy" | "unhealthy" | "degraded";
+
+export type ProviderHealthEvent = {
+  provider: string;
+  timestamp: string;
+  status: ProviderHealthStatus;
+  reason?: string;
+  responseTime?: number;
+};
+
+const MAX_EVENTS_PER_PROVIDER = 20;
+
+/**
+ * In-memory, bounded store for provider health history.
+ * Designed to be easily replaced by Redis or DB later.
+ */
+class ProviderHealthHistoryStore {
+  private history: Record<string, ProviderHealthEvent[]> = {};
+
+  record(event: ProviderHealthEvent) {
+    const events = this.history[event.provider] ?? [];
+
+    events.push(event);
+
+    // Keep only last N events
+    if (events.length > MAX_EVENTS_PER_PROVIDER) {
+      events.shift();
+    }
+
+    this.history[event.provider] = events;
+  }
+
+  getHistory(provider: string): ProviderHealthEvent[] {
+    return this.history[provider] ?? [];
+  }
+
+  getAllHistory(): Record<string, ProviderHealthEvent[]> {
+    return this.history;
+  }
+}
+
+// Singleton instance shared across the app
+export const providerHealthHistoryStore = new ProviderHealthHistoryStore();


### PR DESCRIPTION
## What does this PR do?

This PR introduces provider health history tracking to improve observability and post-incident diagnostics.

A new in-memory, bounded store records health transition events (healthy / unhealthy) for each email provider whenever a definitive success or failure occurs during email delivery.

---

## Why is this needed?

Currently, the system exposes only the current provider health state.  
This makes it difficult to debug intermittent failures, analyze provider stability over time, or correlate circuit breaker behavior with real incidents.

This change adds historical context without altering any existing behavior.

---

## Key highlights

- 📊 Records provider health only at decision points (success/failure)
- 🧠 Centralized at the service layer (no provider-level duplication)
- 🧹 Bounded memory to avoid leaks (last N events per provider)
- 🔌 Designed for easy extension to Redis or persistent storage
- 🔒 No breaking changes, no UI or API modifications

---

## Scope of changes

- Added a reusable provider health history store
- Integrated health event recording into the real email service flow
- Preserved all retry, fallback, and circuit breaker logic

---

## Future work (out of scope)

- Expose provider health history via API
- Visualize trends in the dashboard
- Persist history to Redis / database
