### PR TITLE
feat(api): expose provider health history for observability

### DIFF
--- a/app/api/health/providers/route.ts
+++ b/app/api/health/providers/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server"
+import { providerHealthHistoryStore } from "@/lib/monitoring/providerHealthHistory"
+
+export async function GET() {
+  const data = providerHealthHistoryStore.getAllHistory()
+
+  return NextResponse.json({
+    success: true,
+    providers: data,
+    timestamp: new Date().toISOString(),
+  })
+}


### PR DESCRIPTION
## Summary

This PR introduces a read-only API endpoint to expose provider health history for observability and debugging purposes.

The implementation builds on the existing in-memory provider health tracking and makes the data safely accessible without impacting the email delivery flow.

## What’s included

- New API endpoint: `GET /api/health/providers`
- Returns aggregated provider health history from the monitoring store
- Read-only by design (no mutation or delivery-side effects)
- Follows Next.js App Router conventions

## Why this is useful

- Improves observability and debuggability
- Enables post-incident analysis
- Provides a clean foundation for future UI dashboards or persistence layers
- Keeps monitoring concerns decoupled from delivery logic

## Notes

- Empty response is expected until providers emit health events
- Persistence (Redis/DB) and visualization can be added in follow-up issues
- No breaking changes introduced
